### PR TITLE
Support ignore branch name on hash value.

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -56,8 +56,8 @@ pipeline:
   sftp_cache:
     image: plugins/sftp-cache
     restore: true
-  	mount:
-  	  - node_modules
+    mount:
+      - node_modules
 
   build:
     image: node:latest
@@ -67,6 +67,6 @@ pipeline:
   sftp_cache:
     image: plugins/sftp-cache
     rebuild: true
-  	mount:
-  	  - node_modules
+    mount:
+      - node_modules
 ```

--- a/DOCS.md
+++ b/DOCS.md
@@ -13,6 +13,7 @@ The following parameters are used to configure the plugin:
 * **mount** - one or an array of folders to cache
 * **rebuild** - boolean flag to trigger a rebuild
 * **restore** - boolean flag to trigger a restore
+* **ignore_branch** - boolean flag to ignore commit branch name on hash value
 
 The following secret values can be set to configure the plugin.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ docker run --rm \
   -e PLUGIN_MOUNT=node_modules \
   -e PLUGIN_RESTORE=false \
   -e PLUGIN_REBUILD=true \
+  -e PLUGIN_IGNORE_BRANCH=false \
   -e SFTP_CACHE_SERVER=1.2.3.4:22 \
   -e SFTP_CACHE_PATH=/root/cache \
   -e SFTP_CACHE_USERNAME=root \

--- a/main.go
+++ b/main.go
@@ -49,6 +49,11 @@ func main() {
 			Usage:  "restore the cache directories",
 			EnvVar: "PLUGIN_RESTORE",
 		},
+		cli.BoolFlag{
+			Name:   "ignore_branch",
+			Usage:  "ignore branch name on hash value",
+			EnvVar: "PLUGIN_IGNORE_BRANCH",
+		},
 		cli.StringFlag{
 			Name:   "server",
 			Usage:  "sftp server",
@@ -93,17 +98,18 @@ func run(c *cli.Context) error {
 	}
 
 	plugin := Plugin{
-		Rebuild:  c.Bool("rebuild"),
-		Restore:  c.Bool("restore"),
-		Server:   c.String("server"),
-		Username: c.String("username"),
-		Password: c.String("password"),
-		Key:      c.String("key"),
-		Mount:    c.StringSlice("mount"),
-		Path:     c.String("path"),
-		Repo:     c.String("repo.name"),
-		Default:  c.String("repo.branch"),
-		Branch:   c.String("commit.branch"),
+		IgnoreBranch: c.Bool("ignore_branch"),
+		Rebuild:      c.Bool("rebuild"),
+		Restore:      c.Bool("restore"),
+		Server:       c.String("server"),
+		Username:     c.String("username"),
+		Password:     c.String("password"),
+		Key:          c.String("key"),
+		Mount:        c.StringSlice("mount"),
+		Path:         c.String("path"),
+		Repo:         c.String("repo.name"),
+		Default:      c.String("repo.branch"),
+		Branch:       c.String("commit.branch"),
 	}
 
 	return plugin.Exec()

--- a/plugin.go
+++ b/plugin.go
@@ -15,17 +15,18 @@ import (
 
 // Plugin for caching directories to an SFTP server.
 type Plugin struct {
-	Rebuild  bool
-	Restore  bool
-	Server   string
-	Username string
-	Password string
-	Key      string
-	Mount    []string
-	Path     string
-	Repo     string
-	Branch   string
-	Default  string // default master branch
+	IgnoreBranch bool
+	Rebuild      bool
+	Restore      bool
+	Server       string
+	Username     string
+	Password     string
+	Key          string
+	Mount        []string
+	Path         string
+	Repo         string
+	Branch       string
+	Default      string // default master branch
 }
 
 func (p *Plugin) Exec() error {
@@ -64,7 +65,12 @@ func (p *Plugin) Exec() error {
 // Rebuild the remote cache from the local environment.
 func (p Plugin) ProcessRebuild(c cache.Cache) error {
 	for _, mount := range p.Mount {
-		hash := hasher(mount, p.Branch)
+		var hash string
+		if p.IgnoreBranch {
+			hash = hasher(mount)
+		} else {
+			hash = hasher(mount, p.Branch)
+		}
 		path := filepath.Join(p.Path, p.Repo, hash)
 
 		log.Printf("archiving directory <%s> to remote cache <%s>", mount, path)
@@ -80,7 +86,12 @@ func (p Plugin) ProcessRebuild(c cache.Cache) error {
 // Restore the local environment from the remote cache.
 func (p Plugin) ProcessRestore(c cache.Cache) error {
 	for _, mount := range p.Mount {
-		hash := hasher(mount, p.Branch)
+		var hash string
+		if p.IgnoreBranch {
+			hash = hasher(mount)
+		} else {
+			hash = hasher(mount, p.Branch)
+		}
 		path := filepath.Join(p.Path, p.Repo, hash)
 
 		log.Printf("restoring directory <%s> from remote cache <%s>", mount, path)
@@ -101,8 +112,8 @@ func (p Plugin) ProcessRestore(c cache.Cache) error {
 }
 
 // helper function to hash a file name based on path and branch.
-func hasher(mount, branch string) string {
-	parts := []string{mount, branch}
+func hasher(args ...string) string {
+	parts := args
 
 	// calculate the hash using the branch
 	h := md5.New()

--- a/plugin.go
+++ b/plugin.go
@@ -113,11 +113,9 @@ func (p Plugin) ProcessRestore(c cache.Cache) error {
 
 // helper function to hash a file name based on path and branch.
 func hasher(args ...string) string {
-	parts := args
-
 	// calculate the hash using the branch
 	h := md5.New()
-	for _, part := range parts {
+	for _, part := range args {
 		io.WriteString(h, part)
 	}
 	return fmt.Sprintf("%x", h.Sum(nil))

--- a/plugin.go
+++ b/plugin.go
@@ -98,14 +98,7 @@ func (p Plugin) ProcessRestore(c cache.Cache) error {
 
 		err := cache.RestoreCmd(c, path, mount)
 		if err != nil {
-
-			// this is fallback code to restore from the projects default branch.
-			// hash = hasher(mount, "master")
-			// path = filepath.Join(p.Path, p.Repo, hash)
-			// log.Printf("restoring directory %s from remote cache, using default branch", mount)
-			// if xerr := cache.Restore(c, path, mount); xerr != nil {
 			return err
-			// }
 		}
 	}
 	return nil


### PR DESCRIPTION
**Warring**: The default behavior is create different cache files from each commit branch.

Add `ignore_branch` flag to ignore commit branch name on hash value.

for example:

`ignore_branch` is `false` (default setting). Two commit branch will generate different name of cache file.

`ignore_branch` is `true`. Any commit branch will generate same name of cache file.

cc @tboerger 

Signed-off-by: Bo-Yi Wu appleboy.tw@gmail.com
