### PR TITLE
Fix docs for usage

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -54,6 +54,7 @@ The following is a sample configuration in your .drone.yml file:
 pipeline:
   sftp_cache:
     image: plugins/sftp-cache
+    path: /var/cache/drone
     restore: true
   	mount:
   	  - node_modules
@@ -65,6 +66,7 @@ pipeline:
 
   sftp_cache:
     image: plugins/sftp-cache
+    path: /var/cache/drone
     rebuild: true
   	mount:
   	  - node_modules

--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ docker run --rm \
   -e SFTP_CACHE_SERVER=1.2.3.4:22 \
   -e SFTP_CACHE_PATH=/root/cache \
   -e SFTP_CACHE_USERNAME=root \
-  -e SFTP_CACHE_PRIVATE_KEY=$(cat ~/.ssh/id_rsa) \
+  -e SFTP_CACHE_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" \
   plugins/sftp-cache
 ```


### PR DESCRIPTION
The key is usually several lines long, if there are no commas docker interprets part of the key as the repository:tag, giving this error: `docker: Error parsing reference: "RSA" is not a valid repository/tag.`